### PR TITLE
fix foreign key constraint violations

### DIFF
--- a/spec/factories/invoices.rb
+++ b/spec/factories/invoices.rb
@@ -1,5 +1,7 @@
 FactoryGirl.define do
   factory :invoice do
     status "shipped"
+    merchant
+    customer
   end
 end

--- a/spec/factories/transactions.rb
+++ b/spec/factories/transactions.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :transaction do
-    invoice nil
+    invoice
     credit_card_number "MyText"
     credit_card_expiration_date "2017-06-27"
     result "MyString"

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -3,12 +3,17 @@ require 'rails_helper'
 RSpec.describe InvoiceItem, type: :model do
   it "belongs to an item and an invoice" do
     merchant = Merchant.create(name: "MerchantName")
+    customer = Customer.create(first_name: "FirstName", last_name: "LastName")
     item = Item.create(
                        name: "Item Name",
                        description: "Item Description",
                        unit_price: "25.00",
                        merchant_id: merchant.id)
-    invoice = Invoice.create(status: "shipped")
+    invoice = Invoice.create(
+                             status: "shipped",
+                             merchant_id: merchant.id,
+                             customer_id: customer.id
+                             )
     invoice_item = InvoiceItem.create(
                                       item_id: item.id,
                                       invoice_id: invoice.id,

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -2,7 +2,19 @@ require 'rails_helper'
 
 RSpec.describe Invoice, type: :model do
   it "has a status" do
-    invoice = Invoice.create(status: "shipped")
+    merchant = Merchant.create(name: "MerchantName")
+    customer = Customer.create(first_name: "FirstName", last_name: "LastName")
+    item = Item.create(
+                       name: "Item Name",
+                       description: "Item Description",
+                       unit_price: "25.00",
+                       merchant_id: merchant.id
+                       )
+    invoice = Invoice.create(
+                             status: "shipped",
+                             merchant_id: merchant.id,
+                             customer_id: customer.id
+                             )
     expect(invoice).to be_valid
     expect(invoice).to respond_to(:status)
   end


### PR DESCRIPTION
There were a few foreign key constraint violations that are now fixed (for example, an invoice must have an associated item and merchant, so the way we were creating invoices in the specs was making invalid invoices)